### PR TITLE
Fix openai realtime api config

### DIFF
--- a/twilio-websocket-server/OPENAI_REALTIME_2025.md
+++ b/twilio-websocket-server/OPENAI_REALTIME_2025.md
@@ -29,14 +29,12 @@
 ### Client Events (Client → Server)
 
 #### 1. session.update
-Updates session configuration. Often the first event sent.
+Updates session configuration. Send after `session.created`.
 ```json
 {
   "type": "session.update",
   "session": {
-    "type": "realtime",
-    "model": "gpt-realtime",
-    "modalities": ["audio", "text", "image"],
+    "modalities": ["audio", "text"],
     "voice": "alloy",
     "instructions": "System instructions",
     "input_audio_format": "g711_ulaw",
@@ -246,7 +244,8 @@ No automatic turn detection; responses triggered manually.
 ## Best Practices
 
 ### 1. Session Configuration
-- Always set `session.type: "realtime"` (required)
+- Specify the model via WebSocket URL: `wss://api.openai.com/v1/realtime?model=gpt-realtime`
+- Do not include `model` or `type` in `session.update`
 - Configure VAD based on use case:
   - Phone: `server_vad` with 500ms silence
   - Desktop: `semantic_vad` for natural conversation

--- a/twilio-websocket-server/README.md
+++ b/twilio-websocket-server/README.md
@@ -106,3 +106,4 @@ wscat -c ws://localhost:3001?secret=your_openai_secret
 - The server maintains the WebSocket bridge between Twilio and OpenAI
 - Audio is passed through in G.711 μ-law format (no conversion needed)
 - VAD (Voice Activity Detection) is handled by OpenAI
+ - For GA Realtime API, do not send the `OpenAI-Beta: realtime=v1` header

--- a/twilio-websocket-server/server.js
+++ b/twilio-websocket-server/server.js
@@ -155,10 +155,9 @@ wss.on('connection', async (twilioWS, request) => {
       
       console.log('Connecting to OpenAI with model:', model);
       
-      // Prefer Authorization header over insecure subprotocol for production
+      // Prefer Authorization header over insecure subprotocol for production (GA Realtime requires no beta header)
       const headers = {
-        Authorization: `Bearer ${providedSecret}`,
-        'OpenAI-Beta': 'realtime=v1'
+        Authorization: `Bearer ${providedSecret}`
       };
       if (process.env.OPENAI_ORG_ID) headers['OpenAI-Organization'] = process.env.OPENAI_ORG_ID;
       if (process.env.OPENAI_PROJECT_ID) headers['OpenAI-Project'] = process.env.OPENAI_PROJECT_ID;
@@ -172,8 +171,7 @@ wss.on('connection', async (twilioWS, request) => {
       oaiWS.on('open', () => {
         console.log('Connected to OpenAI');
         
-        // Configure session according to OpenAI Realtime API documentation
-        // Note: modalities and audio formats are set in token creation, not session.update
+        // Configure session according to OpenAI Realtime GA API documentation
         const sessionConfig = {
           // Voice selection (all 11 available voices)
           voice: process.env.REALTIME_DEFAULT_VOICE || 'alloy',
@@ -192,12 +190,11 @@ CONVERSATION: Greet warmly. Listen actively. Respond helpfully. Confirm understa
           
           // Turn detection (VAD) configuration
           turn_detection: {
-            type: process.env.REALTIME_VAD_MODE || 'server_vad',  // server_vad or none
+            type: process.env.REALTIME_VAD_MODE || 'server_vad',  // server_vad | semantic_vad | none
             threshold: parseFloat(process.env.REALTIME_VAD_THRESHOLD || '0.5'),  // 0.0 to 1.0
             prefix_padding_ms: parseInt(process.env.REALTIME_VAD_PREFIX_MS || '300'),
             silence_duration_ms: parseInt(process.env.REALTIME_VAD_SILENCE_MS || '500'),
-            create_response: process.env.REALTIME_VAD_CREATE_RESPONSE ? process.env.REALTIME_VAD_CREATE_RESPONSE === 'true' : true,
-            interrupt_response: process.env.REALTIME_VAD_INTERRUPT ? process.env.REALTIME_VAD_INTERRUPT === 'true' : true
+            create_response: process.env.REALTIME_VAD_CREATE_RESPONSE ? process.env.REALTIME_VAD_CREATE_RESPONSE === 'true' : true
           },
           
           // Input audio transcription (optional)


### PR DESCRIPTION
Align OpenAI Realtime API configuration with GA specification to resolve `api_version_mismatch` errors by removing the beta header and updating session event types.

---
<a href="https://cursor.com/background-agent?bcId=bc-3667c77b-c6af-4123-95fe-a6f5c77ec5ca">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3667c77b-c6af-4123-95fe-a6f5c77ec5ca">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

