### PR TITLE
Handle npm and OpenAI errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "jest --passWithNoTests"
+    "test": "jest --passWithNoTests",
+    "ws:dev": "NODE_ENV=development node twilio-websocket-server/server.js",
+    "ws:start": "NODE_ENV=production node twilio-websocket-server/server.js"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",

--- a/twilio-websocket-server/README.md
+++ b/twilio-websocket-server/README.md
@@ -107,3 +107,12 @@ wscat -c ws://localhost:3001?secret=your_openai_secret
 - Audio is passed through in G.711 μ-law format (no conversion needed)
 - VAD (Voice Activity Detection) is handled by OpenAI
  - For GA Realtime API, do not send the `OpenAI-Beta: realtime=v1` header
+
+## Deployment tips (avoiding npm ERR! path /app and SIGTERM)
+
+- Ensure the working directory contains this folder's `package.json` when starting. If your platform sets `WORKDIR /app`, either deploy this folder as its own service or run Node directly:
+  - Start command: `node server.js` (instead of `npm start`) so the app is PID 1 and handles signals correctly.
+- This server now handles SIGTERM/SIGINT and closes gracefully. If your platform still reports `npm ERR! signal SIGTERM`, prefer running `node server.js`.
+- From the monorepo root, you can also use:
+  - `npm run ws:dev`
+  - `npm run ws:start`


### PR DESCRIPTION
Add `session.type` to OpenAI config, implement graceful shutdown, and update deployment guidance to fix OpenAI `missing_required_parameter` and npm SIGTERM errors.

The OpenAI Realtime API requires `type: 'session'`, which was previously stripped, causing a `missing_required_parameter` error. Graceful SIGTERM/SIGINT handling was added to prevent npm from reporting command failures on process termination. Deployment guidance and root npm scripts were also updated to address `npm error path /app` by clarifying how to run the server with the correct working directory and signal handling.

---
<a href="https://cursor.com/background-agent?bcId=bc-cb531cfa-c98c-4b7e-a038-ed24c1ab466c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cb531cfa-c98c-4b7e-a038-ed24c1ab466c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

