### PR TITLE
Handle invalid openai session type error

### DIFF
--- a/twilio-websocket-server/server.js
+++ b/twilio-websocket-server/server.js
@@ -173,7 +173,6 @@ wss.on('connection', async (twilioWS, request) => {
         
         // Configure session according to OpenAI Realtime GA API documentation
         const sessionConfig = {
-          type: 'session',
           // Voice selection (all 11 available voices)
           voice: process.env.REALTIME_DEFAULT_VOICE || 'alloy',
           
@@ -221,7 +220,6 @@ CONVERSATION: Greet warmly. Listen actively. Respond helpfully. Confirm understa
             cleanSession[key] = value;
           }
         }
-        if (!cleanSession.type) cleanSession.type = 'session';
         
         // Store config for later use after session.created
         state.pendingSessionConfig = cleanSession;


### PR DESCRIPTION
Remove invalid `session.type: 'session'` from WebSocket `session.update` to fix OpenAI API error.

The OpenAI Realtime API expects `session.type` to be 'realtime' (or 'transcription') only during ephemeral token creation. When sending `session.update` via WebSocket, `session.type` should not be included at all. Sending `session.type: 'session'` resulted in an `invalid_value` error from OpenAI.

---
<a href="https://cursor.com/background-agent?bcId=bc-f431f71b-da3e-447b-bd4f-edd178b47f00">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f431f71b-da3e-447b-bd4f-edd178b47f00">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

